### PR TITLE
Compatibility with Windows and node.js 0.12, io.js

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,6 +35,6 @@ deploy:
     draft: false
     prerelease: false
     auth_token:
-      secure: Y4nMpyIHHm1pH9cekqL5vj6xGSs98R3rgnQVd4awCWrxaO6qq53Ec007qm96lWE6
+      secure: "YLmEA1WoiL7X7fEltpqNpUrPFfmcx1Iaj2zp/QkRDfTzDeFZuOXEcUJuss2ZlNS2"
     on:
       appveyor_repo_tag: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,29 @@
+environment:
+  matrix:
+    - nodejs_version: 0.8
+    - nodejs_version: 0.10
+    - nodejs_version: 0.12
+    - nodejs_version: 1.0
+platform:
+ - x86
+ - x64
+install:
+  - SET "PATH=node_modules\.bin;%PATH%"
+  - SET "GYP_MSVS_VERSION=2013"
+  - IF %platform% == x64 (
+      SET "ARCHPATH=x64/" ;
+      SET "PATH=C:\Python27-x64;%PATH%" ;
+      CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+    )
+  - IF %platform% == x86 (
+      SET "ARCHPATH=" ;
+      SET "PATH=C:\Python27;%PATH%" ;
+      CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64_86
+    )
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm install --build-from-source
+build_script:
+  - npm run-script package
+  - IF NOT "%APPVEYOR_REPO_TAG_NAME%" == "" ( dir build\stage\%APPVEYOR_REPO_PATH%\releases\download\%APPVEYOR_REPO_TAG_NAME% )
+test_script:
+  - IF NOT "%nodejs_version%" == "1.0" ( npm test )

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: 0.8
     - nodejs_version: 0.10
     - nodejs_version: 0.12
     - nodejs_version: 1.0
@@ -8,7 +7,6 @@ platform:
  - x86
  - x64
 install:
-  - SET "PATH=node_modules\.bin;%PATH%"
   - SET "GYP_MSVS_VERSION=2013"
   - IF %platform% == x64 (
       SET "ARCHPATH=x64/" ;
@@ -20,6 +18,7 @@ install:
       SET "PATH=C:\Python27;%PATH%" ;
       CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64_86
     )
+  - ps: $env:APPVEYOR_REPO_PATH = $env:APPVEYOR_REPO_NAME.replace('/', '\')
   - ps: Install-Product node $env:nodejs_version $env:platform
   - npm install --build-from-source
 build_script:
@@ -27,3 +26,15 @@ build_script:
   - IF NOT "%APPVEYOR_REPO_TAG_NAME%" == "" ( dir build\stage\%APPVEYOR_REPO_PATH%\releases\download\%APPVEYOR_REPO_TAG_NAME% )
 test_script:
   - IF NOT "%nodejs_version%" == "1.0" ( npm test )
+artifacts:
+  - path: build\stage\$(APPVEYOR_REPO_PATH)\releases\download\$(APPVEYOR_REPO_TAG_NAME)\*.tar.gz
+    name: binding
+deploy:
+  - provider: GitHub
+    artifact: binding
+    draft: false
+    prerelease: false
+    auth_token:
+      secure: Y4nMpyIHHm1pH9cekqL5vj6xGSs98R3rgnQVd4awCWrxaO6qq53Ec007qm96lWE6
+    on:
+      appveyor_repo_tag: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
+/node_modules
+/build
+/lib/binding
 .idea
-node_modules
-build
 npm-debug.log
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
   - "0.12"
   - "iojs"
@@ -10,5 +9,13 @@ install:
 script:
   - npm run-script package
   - if [ -n "${TRAVIS_TAG}" ]; then ls -l build/stage/${TRAVIS_REPO_SLUG}/releases/download/${TRAVIS_TAG} ; fi
-test:
   - npm test
+deploy:
+  - provider: releases
+    file_glob: true
+    file: build/stage/${TRAVIS_REPO_SLUG}/releases/download/${TRAVIS_TAG}/*.tar.gz
+    skip_cleanup: true
+    api_key:
+      secure: OzxP0xdaX9bBdxvj/yqnFQ3rUHU1iVBXNX6a6bXWs68Bxhg+t5cjHxa8ECGMby1R4U+vQvENvyK8/8FzSu55rKPYyoj3k0Gc4diy+6UIHUDZAwk5zJl+914JhMGYdXRDx2dGOwM8xeEaNU0PUV0LT+AX+TbuyfFIsgnB/+V56iiCVI7or9jF0oqR5Txw7vgm7xicaKUvTZ6q05evoVtu9Woo0AypQqLChXPTy/pQIWvDZn8kQtsBqXz+hg97HIrxRKwp/ZVRENw6Y1CE2cGGMjynnYiI4s5KTuYsljD809wz3+7ozlijPw3JDh+qzzIR7R2vjgYgt0DGA193gxnNAxXxGQB3cAXrqr5hHlWzB+CcBisMK4XNHikGdCofup5be+NYHuyFgAep7N0lvfE3RUJC7DJAL0LQOhBSgI3es2th0hfAdSvW12ELOggbpaO0DFmIn0oTSiptDdneSUrXDCdmQIJGeYFlkKrLES1D96geT4cKaKI9vEDcU5S+Jwlv6p6nXydJ9OfsK27DFhi6NpSPPkvVAeqdqlj3MZvLq+Kh7fMrh3aSMve/Gm0SNuieSi/paU0qU2e8fr5L5pEIixL4HPhG8bTVx06TB9i4KOhqym+Y6GY3xqdSiEhuUFYF6EQnCJUiv/31XbN2FWgF5lxNobJwDeAVRMzcQpIGgFw=
+    on:
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ deploy:
     file: build/stage/${TRAVIS_REPO_SLUG}/releases/download/${TRAVIS_TAG}/*.tar.gz
     skip_cleanup: true
     api_key:
-      secure: OzxP0xdaX9bBdxvj/yqnFQ3rUHU1iVBXNX6a6bXWs68Bxhg+t5cjHxa8ECGMby1R4U+vQvENvyK8/8FzSu55rKPYyoj3k0Gc4diy+6UIHUDZAwk5zJl+914JhMGYdXRDx2dGOwM8xeEaNU0PUV0LT+AX+TbuyfFIsgnB/+V56iiCVI7or9jF0oqR5Txw7vgm7xicaKUvTZ6q05evoVtu9Woo0AypQqLChXPTy/pQIWvDZn8kQtsBqXz+hg97HIrxRKwp/ZVRENw6Y1CE2cGGMjynnYiI4s5KTuYsljD809wz3+7ozlijPw3JDh+qzzIR7R2vjgYgt0DGA193gxnNAxXxGQB3cAXrqr5hHlWzB+CcBisMK4XNHikGdCofup5be+NYHuyFgAep7N0lvfE3RUJC7DJAL0LQOhBSgI3es2th0hfAdSvW12ELOggbpaO0DFmIn0oTSiptDdneSUrXDCdmQIJGeYFlkKrLES1D96geT4cKaKI9vEDcU5S+Jwlv6p6nXydJ9OfsK27DFhi6NpSPPkvVAeqdqlj3MZvLq+Kh7fMrh3aSMve/Gm0SNuieSi/paU0qU2e8fr5L5pEIixL4HPhG8bTVx06TB9i4KOhqym+Y6GY3xqdSiEhuUFYF6EQnCJUiv/31XbN2FWgF5lxNobJwDeAVRMzcQpIGgFw=
+      secure: "NBK4l4BI/XeOuoi9azTi6fwLT2Q3Mek7wodW2Wnx4CQcmwCGp7+fDXIPwVdmJMg4g5CosC8sOTdR9I7t9hSZ/xK3hIzXXMc17hKZ2BrViCCj06Hee1q1042LlycWPrFM8O84jzAnnR1iKJdiArQr+SY5TvLIs94JFzYUqQG8cDQ="
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "0.10"
@@ -6,3 +7,7 @@ node_js:
 env:
     global:
      - TRAVIS=true
+install:
+  - npm install --build-from-source
+  - npm run-script package
+  - ls build/stage/${TRAVIS_REPO_SLUG}/releases/download/${TRAVIS_TAG}/*.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 sudo: false
 language: node_js
 node_js:
+  - "0.8"
   - "0.10"
   - "0.12"
   - "iojs"
-env:
-    global:
-     - TRAVIS=true
 install:
   - npm install --build-from-source
   - npm run-script package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
-env: 
+  - "0.12"
+  - "iojs"
+env:
     global:
      - TRAVIS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,8 @@ node_js:
   - "iojs"
 install:
   - npm install --build-from-source
+script:
   - npm run-script package
-  - ls build/stage/${TRAVIS_REPO_SLUG}/releases/download/${TRAVIS_TAG}/*.tar.gz
+  - if [ -n "${TRAVIS_TAG}" ]; then ls -l build/stage/${TRAVIS_REPO_SLUG}/releases/download/${TRAVIS_TAG} ; fi
+test:
+  - npm test

--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,18 @@ all: test
 build: clean configure compile
 
 configure:
-		node-gyp configure
+		node-pre-gyp configure
 
 compile: configure
-		node-gyp build
-			npm install .
+		node-pre-gyp build
+		npm install .
 
 test: build
 		@./node_modules/nodeunit/bin/nodeunit \
 					$(TESTS)
 
 clean:
-		node-gyp clean
+		node-pre-gyp clean
 
 
 .PHONY: clean test build

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Node library which uses native calls to locate the mac address for
 a given interface name.
 
-Currently works on OSX, Solaris and Linux, working on support windows at the moment.
+Currently works on OSX, Solaris, Linux and Windows. Maybe FreeBSD is next?
 
--[![Build Status](https://secure.travis-ci.org/wolfeidau/node-netif.png)](http://travis-ci.org/wolfeidau/node-netif)
+[![Build Status](https://secure.travis-ci.org/wolfeidau/node-netif.png)](http://travis-ci.org/wolfeidau/node-netif)
 
 ## Getting Started
 Install the module with: `npm install netif`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ a given interface name.
 Currently works on OSX, Solaris, Linux and Windows. Maybe FreeBSD is next?
 
 [![Build Status](https://secure.travis-ci.org/wolfeidau/node-netif.png)](http://travis-ci.org/wolfeidau/node-netif)
+[![Build status](https://ci.appveyor.com/api/projects/status/6n0xxvu2a3bqxk3m?svg=true)](https://ci.appveyor.com/project/jpommerening/node-netif-4a9h8)
 
 ## Getting Started
 Install the module with: `npm install netif`

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,16 @@
             ],
             "include_dirs":[
                 "<!(node -e \"require('nan')\")"
+            ],
+            "conditions":[
+                [
+                    "OS=='win'",
+                    {
+                        "link_settings":{
+                            "libraries":["iphlpapi.lib"]
+                        }
+                    }
+                ]
             ]
         },
         {

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,12 +1,23 @@
 {
     "targets":[
         {
-            "target_name":"netif",
+            "target_name":"<(module_name)",
             "sources":[
                 "src/netif.cc"
             ],
             "include_dirs":[
                 "<!(node -e \"require('nan')\")"
+            ]
+        },
+        {
+            "target_name":"action_after_build",
+            "type":"none",
+            "dependencies":["<(module_name)"],
+            "copies":[
+                {
+                    "files":["<(PRODUCT_DIR)/<(module_name).node"],
+                    "destination":"<(module_path)"
+                }
             ]
         }
     ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,6 +4,9 @@
             "target_name":"netif",
             "sources":[
                 "src/netif.cc"
+            ],
+            "include_dirs":[
+                "<!(node -e \"require('nan')\")"
             ]
         }
     ]

--- a/lib/netif.js
+++ b/lib/netif.js
@@ -5,7 +5,10 @@
  * Copyright (c) 2012 Mark Wolfe
  * Licensed under the MIT license.
  */
-var bindings = require('bindings')('netif');
+var binary = require('node-pre-gyp');
+var path = require('path');
+var binding_path = binary.find(path.resolve(path.join(__dirname, '../package.json')));
+var binding = require(binding_path);
 
 /*
  * Locate the mac address for a given interface name.
@@ -13,5 +16,5 @@ var bindings = require('bindings')('netif');
  * @param interfaceName - The name for the interface for example eth0 in linux.
  */
 module.exports.getMacAddress = function(interfaceName) {
-  return bindings.getMacAddress(interfaceName);
+  return binding.getMacAddress(interfaceName);
 }

--- a/lib/netif.js
+++ b/lib/netif.js
@@ -6,9 +6,18 @@
  * Licensed under the MIT license.
  */
 var binary = require('node-pre-gyp');
+var os = require('os');
 var path = require('path');
 var binding_path = binary.find(path.resolve(path.join(__dirname, '../package.json')));
 var binding = require(binding_path);
+
+function getDefaultInterfaceName() {
+  var interfaces = os.networkInterfaces();
+  for (var name in interfaces) {
+    if (!interfaces[name].length) continue;
+    if (!(interfaces[name][0].internal)) return name;
+  }
+}
 
 /*
  * Locate the mac address for a given interface name.
@@ -16,5 +25,5 @@ var binding = require(binding_path);
  * @param interfaceName - The name for the interface for example eth0 in linux.
  */
 module.exports.getMacAddress = function(interfaceName) {
-  return binding.getMacAddress(interfaceName);
+  return binding.getMacAddress(interfaceName || getDefaultInterfaceName());
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "make test"
   },
   "dependencies": {
-    "bindings": "1.0.0"
+    "bindings": "1.0.0",
+    "nan": "~1.8.4"
   },
   "devDependencies": {
     "nodeunit": "*"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",
     "package": "node-pre-gyp package",
-    "test": "make test"
+    "test": "nodeunit test"
   },
   "dependencies": {
     "nan": "~1.8.4",

--- a/package.json
+++ b/package.json
@@ -21,17 +21,28 @@
     }
   ],
   "main": "lib/netif",
+  "binary": {
+    "module_name": "netif",
+    "module_path": "./lib/binding/{node_abi}-{platform}-{arch}",
+    "host": "https://github.com",
+    "remote_path": "/wolfeidau/node-{name}/releases/download/v{version}/",
+    "package_name": "{module_name}-{node_abi}-{platform}-{arch}.tar.gz"
+  },
   "engines": {
     "node": ">= 0.6.0"
   },
   "scripts": {
-    "install": "node-gyp rebuild",
+    "install": "node-pre-gyp install --fallback-to-build",
+    "package": "node-pre-gyp package",
     "test": "make test"
   },
   "dependencies": {
-    "bindings": "1.0.0",
-    "nan": "~1.8.4"
+    "nan": "~1.8.4",
+    "node-pre-gyp": "~0.6.8"
   },
+  "bundledDependencies": [
+    "node-pre-gyp"
+  ],
   "devDependencies": {
     "nodeunit": "*"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node-pre-gyp"
   ],
   "devDependencies": {
-    "nodeunit": "*"
+    "nodeunit": "~0.8.8"
   },
   "keywords": [
     "ifconfig",

--- a/test/netif_test.js
+++ b/test/netif_test.js
@@ -1,31 +1,26 @@
 var netif = require('../lib/netif');
 
 var os = require('os');
+var interfaces;
+var interfaceNames;
 
 exports['netif'] = {
   setUp: function (done) {
-    // setup here
+    interfaces = os.networkInterfaces();
+    interfaceNames = Object.keys(interfaces);
+    console.log('\u2699 Interfaces: ' + interfaceNames.join(', '));
     done();
   },
   'should look up interface given an ethernet interface name': function (test) {
-    test.expect(1);
-    // tests here
-    switch (os.platform()) {
-      case 'darwin':
-        test.ok(netif.getMacAddress('en0'), "should not error out"); // osx
-        break;
-      case 'linux':
-        if (process.env.TRAVIS) // cause travis is different..
-            test.ok(netif.getMacAddress('venet0'), "should not error out"); // linux
-	else
-            test.ok(netif.getMacAddress('eth0'), "should not error out"); // linux
-        break;
-      case 'sunos':
-        test.ok(netif.getMacAddress('net0'), "should not error out"); // solaris
-        break;
-      default:
-        throw Error('unsupported os for this module.');
-    }
+    test.expect((2 * interfaceNames.length) + 1);
+
+    test.ok(interfaceNames.length > 0);
+
+    interfaceNames.forEach(function (name) {
+      var mac = netif.getMacAddress(name);
+      test.ok(mac, "should return *something* for " + name);
+      test.ok(/([0-9a-f]{2}:){5}[0-9a-f]{2}/i.test(mac), "should return a MAC address for " + name);
+    });
     test.done();
   }
 };

--- a/test/netif_test.js
+++ b/test/netif_test.js
@@ -22,5 +22,18 @@ exports['netif'] = {
       test.ok(/([0-9a-f]{2}:){5}[0-9a-f]{2}/i.test(mac), "should return a MAC address for " + name);
     });
     test.done();
+  },
+  'should look up the first non-loopback interface if no name was given': function (test) {
+    test.expect(3);
+
+    var mac = netif.getMacAddress();
+    test.ok(mac, "should return *something*");
+    test.ok(/([0-9a-f]{2}:){5}[0-9a-f]{2}/i.test(mac), "should return a MAC address");
+
+    test.ok(interfaceNames.filter(function (name) {
+      return (interfaces[name].length > 0) && !(interfaces[name][0].internal);
+    }).map(netif.getMacAddress).indexOf(mac) >= 0);
+
+    test.done();
   }
 };

--- a/test/netif_test.js
+++ b/test/netif_test.js
@@ -1,4 +1,4 @@
-var netif = require('bindings')('netif');
+var netif = require('../lib/netif');
 
 var os = require('os');
 


### PR DESCRIPTION
Hi,

here's a whole bunch of changes, but I rebased them so that there is roughly one feature per commit.
It looks like it has been some time since anything happened here. I'm not sure you're interested in these changes (or maintaining `netif` at all), so pick what you like!

d4ebe34 introduces compatibility with node.js 0.12 and newer using [nan](/nodejs/nan)
933c742 adds [node-pre-gyp](/mapbox/node-pre-gyp) to the build process, allowing to provide pre-compiled binary packages, but falling back to building from source during installation
7f7dbcd restructures the tests so they don't rely on specific network interface names
ae66382 adds windows compatibility
59786e9 adds an [appveyor](https://ci.appveyor.com/project/jpommerening/node-netif) configuration
f9bde6a adds deployment steps to the Travis and Appveyor builds to upload the compiled node.js bindings to GitHub (my test release: [v0.2.0-rc6](/jpommerening/node-netif/releases/tag/v0.2.0-rc6), note: this is still using my GitHub [API tokens](https://github.com/settings/tokens))
d6918b0 resolves #1 ;)

If you don't like these changes, just let me know. I can maintain my own fork and release it under a different name. Otherwise, ask my anything, I'm happy to explain each of these changes in detail!

_Edit:_ I couldn't find a way to get this to work under node.js 0.8. There's always a dependency deep down in the dep-tree that is using the caret (`^`) notation, not supported by old `npm`.
